### PR TITLE
update pyobjc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/Khan/pyobjc-core
-git+https://github.com/Khan/pyobjc-framework-Cocoa
-git+https://github.com/Khan/pyobjc-framework-FSEvents
+pyobjc-core==3.0.4
+pyobjc-framework-Cocoa==3.0.4
+pyobjc-framework-FSEvents==3.0.4


### PR DESCRIPTION
ran into this issue on a new install on El Capitan. Google SDK 98.0.0. updating to the latest libs on PyPI fixes it.

https://bitbucket.org/ronaldoussoren/pyobjc/issues/112/installation-on-yosemite-pyobjc-core