### PR TITLE
Handle ResponseNotReady error returned by /_ah/remote_api

### DIFF
--- a/python/google/appengine/tools/appengine_rpc_httplib2.py
+++ b/python/google/appengine/tools/appengine_rpc_httplib2.py
@@ -31,6 +31,7 @@ import re
 import time
 import urllib
 
+import httplib
 import httplib2
 
 from oauth2client import client
@@ -262,6 +263,13 @@ class HttpRpcServerHttpLib2(object):
 
         logger.info('Got access token error', exc_info=1)
         response_info = httplib2.Response({'status': 401})
+        response_info.reason = str(e)
+        response = ''
+
+      except httplib.ResponseNotReady as e:
+
+        logger.info('Got response not ready error', exc_info=1)
+        response_info = httplib2.Response({'status': 500})
         response_info.reason = str(e)
         response = ''
 


### PR DESCRIPTION
## Summary:
We started seeing this error on June 1st 2022, while migrating CMS topic
revisions to be in Course Editor shape.

I have never seen this kind of error before in devshell. It was blocking our courses
migration efforts in all the locales, requiring to retry many times before a migration
script would succeed. Since migration scripts might have to get hundreds of TopicRevision
entities from the datastore in a run, any one single `ResponseNotReady` error fails
a run.

I have opened a Google Cloud Support ticket: https://console.cloud.google.com/support/cases/detail/v2/29913687?project=khan-academy

But we need to continue the migration effort, running these scripts, while Google
investigates.

To that end, I found that patching `HttpRpcServerHttpLib2#Send` to handle this
specific exception and re-try the API request resolves the issue.

Issue: https://khanacademy.slack.com/archives/C023LS7QB1B/p1654178985570379

Test Plan:
 - Use `tools/devshell.py --prod` to get/put datastore entities
 - Verify no `httplib.ResponseNotReady` errors are seen