### PR TITLE
Add logging for canonicalization

### DIFF
--- a/python/google/appengine/ext/remote_api/handler.py
+++ b/python/google/appengine/ext/remote_api/handler.py
@@ -244,7 +244,7 @@ class RemoteDatastoreStub(apiproxy_stub.APIProxyStub):
       get_response = datastore_pb.GetResponse()
       self.__call('datastore_v3', 'Get', get_request, get_response)
       _CanonicalizeGetResponse(get_response)
-      logging.info('Canonicalized response %s' % get_response)
+      logging.info('Response was canonicalized')
       entities = get_response.entity_list()
       assert len(entities) == request.precondition_size()
       for precondition, entity in zip(preconditions, entities):

--- a/python/google/appengine/ext/remote_api/handler.py
+++ b/python/google/appengine/ext/remote_api/handler.py
@@ -244,6 +244,7 @@ class RemoteDatastoreStub(apiproxy_stub.APIProxyStub):
       get_response = datastore_pb.GetResponse()
       self.__call('datastore_v3', 'Get', get_request, get_response)
       _CanonicalizeGetResponse(get_response)
+      logging.info('Canonicalized response %s' % get_response)
       entities = get_response.entity_list()
       assert len(entities) == request.precondition_size()
       for precondition, entity in zip(preconditions, entities):

--- a/python/google/appengine/ext/remote_api/remote_api_stub.py
+++ b/python/google/appengine/ext/remote_api/remote_api_stub.py
@@ -70,6 +70,7 @@ import Cookie
 import datetime
 import hashlib
 import inspect
+import logging
 import os
 import pickle
 import random
@@ -438,6 +439,7 @@ class RemoteDatastoreStub(RemoteStub):
           else:
             new_response.add_entity()
       get_response.CopyFrom(new_response)
+      logging.info('New response %s', get_response)
 
   def _Dynamic_Put(self, put_request, put_response):
     if put_request.has_transaction():

--- a/python/google/appengine/ext/remote_api/remote_api_stub.py
+++ b/python/google/appengine/ext/remote_api/remote_api_stub.py
@@ -70,7 +70,6 @@ import Cookie
 import datetime
 import hashlib
 import inspect
-import logging
 import os
 import pickle
 import random
@@ -439,7 +438,6 @@ class RemoteDatastoreStub(RemoteStub):
           else:
             new_response.add_entity()
       get_response.CopyFrom(new_response)
-      logging.info('New response %s' % get_response)
 
   def _Dynamic_Put(self, put_request, put_response):
     if put_request.has_transaction():

--- a/python/google/appengine/ext/remote_api/remote_api_stub.py
+++ b/python/google/appengine/ext/remote_api/remote_api_stub.py
@@ -439,7 +439,7 @@ class RemoteDatastoreStub(RemoteStub):
           else:
             new_response.add_entity()
       get_response.CopyFrom(new_response)
-      logging.info('New response %s', get_response)
+      logging.info('New response %s' % get_response)
 
   def _Dynamic_Put(self, put_request, put_response):
     if put_request.has_transaction():


### PR DESCRIPTION
## Summary:
In https://github.com/Khan/frankenserver/pull/7 we patched the remote
API to canonicalize entities in order to allow our datastore migration
to continue.

However it appears that this mitigation didn't work. It's possible that
the mitigation didn't work because the code wasn't deployed in all the
right places. It's also possible that something is wrong with the mitigation
and it isn't doing what we think it should be doing.

This change should allow us to validate the first possibility by adding log
messages showing that the new code is running.

We've decided for now to hold off on further logging due to not understanding
exactly what would be logged if we log the response. We want to avoid adding
PII or huge amounts of data to the logs.

We may do another PR with further logging if it turns out that our code IS being
run, but that the mitigation still isn't working.

Issue: None

## Test plan:
- None
- Deploy to production and hope to see log messages appear