### PR TITLE
[🔥AUDIT🔥] Ignore whether we can start the datastore emulator when running externally.

### DIFF
--- a/python/google/appengine/tools/devappserver2/devappserver2.py
+++ b/python/google/appengine/tools/devappserver2/devappserver2.py
@@ -168,7 +168,8 @@ class DevelopmentServer(object):
 
   def _fail_for_using_datastore_emulator_from_legacy_sdk(self):
     """Error out on attempts to use the emulator from the legacy GAE SDK."""
-    if (self._options.support_datastore_emulator and (
+    if (self._options.support_datastore_emulator and
+        os.environ.get('DATASTORE_EMULATOR_HOST') is None and (
         self._options.datastore_emulator_cmd is None
         or not os.path.exists(self._options.datastore_emulator_cmd))):
       raise MissingDatastoreEmulatorError(


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The dev-appserver makes sure it can start up the datastore emulator
when you run in "datastore emulator" mode.  However, if you pass in an
emulator host-port (via an envvar) then the dev-appserver never tries
to start up an emulator, so that check is spurious.  And in fact, it
was failing for us -- we don't have the proper binary installed in
frankenserver -- so it's good to bypass it.

Issue: https://khanacademy.atlassian.net/browse/INFRA-8969

## Test plan:
I successfully ran
```
env DATASTORE_EMULATOR_HOST=localhost:8301 make serve-python HOST= FLAGS=--support_datastore_emulator=true
```
with this patch applied.